### PR TITLE
fix(repo): correct arch_short variable value

### DIFF
--- a/ansible/roles/test/ohpc-lenovo-repo.yml
+++ b/ansible/roles/test/ohpc-lenovo-repo.yml
@@ -8,7 +8,7 @@
     proxy: 10.241.58.130:3128
     cluster: lenovo
     arch: x86_64
-    arch_short: x86
+    arch_short: x64
 
   handlers:
     - name: Include handlers


### PR DESCRIPTION
The value of the `arch_short` variable was incorrect. It has been corrected from `x86` to `x64` to accurately reflect the architecture.