### PR TITLE
refactor(obs): convert stunnel and openvpn configs to templates

### DIFF
--- a/ansible/roles/obs/ohpc-lenovo-c3.yml
+++ b/ansible/roles/obs/ohpc-lenovo-c3.yml
@@ -9,6 +9,8 @@
     obs_worker_jobs: 6
     container_tag: amd64
     obs_repository_server: 10.255.254.0
+    stunnel_remote_port: 8444
+    openvpn_ifconfig: "10.255.254.1 10.255.254.0"
 
   handlers:
     - name: Include handlers
@@ -20,6 +22,9 @@
 
     - name: Include automatic-updates.yml
       ansible.builtin.include_tasks: ../common/automatic-updates.yml
+
+    - name: Import ohpc-lenovo-common.yml
+      ansible.builtin.import_tasks: ../test/ohpc-lenovo-common.yml
 
     - name: Create OBS directories
       ansible.builtin.file:
@@ -65,7 +70,7 @@
           - git
 
     - name: Install stunnel configuration
-      ansible.builtin.copy:
+      ansible.builtin.template:
         src: stunnel.conf
         dest: /etc/stunnel/stunnel.conf
         owner: root
@@ -73,7 +78,7 @@
         mode: "0600"
 
     - name: Install openvpn configuration
-      ansible.builtin.copy:
+      ansible.builtin.template:
         src: openvpn-obs.conf
         dest: /etc/openvpn/client/obs.conf
         owner: root

--- a/ansible/roles/obs/ohpc-lenovo-repo.yml
+++ b/ansible/roles/obs/ohpc-lenovo-repo.yml
@@ -9,6 +9,8 @@
     obs_worker_jobs: 6
     container_tag: amd64
     obs_repository_server: 10.255.255.0
+    stunnel_remote_port: 8443
+    openvpn_ifconfig: "10.255.255.1 10.255.255.0"
 
   handlers:
     - name: Include handlers
@@ -50,7 +52,7 @@
           - git
 
     - name: Install stunnel configuration
-      ansible.builtin.copy:
+      ansible.builtin.template:
         src: stunnel.conf
         dest: /etc/stunnel/stunnel.conf
         owner: root
@@ -58,7 +60,7 @@
         mode: "0600"
 
     - name: Install openvpn configuration
-      ansible.builtin.copy:
+      ansible.builtin.template:
         src: openvpn-obs.conf
         dest: /etc/openvpn/client/obs.conf
         owner: root

--- a/ansible/roles/obs/templates/openvpn-obs.conf
+++ b/ansible/roles/obs/templates/openvpn-obs.conf
@@ -1,6 +1,6 @@
 dev tun1
 remote localhost
-ifconfig 10.255.255.1 10.255.255.0
+ifconfig {{ openvpn_ifconfig }}
 secret /etc/openvpn/client/obs.key
 cipher AES-256-CBC
 keepalive 10 60

--- a/ansible/roles/obs/templates/stunnel.conf
+++ b/ansible/roles/obs/templates/stunnel.conf
@@ -1,5 +1,5 @@
 [openvpn]
 client = yes
 accept = 30000
-connect = obs.openhpc.community:8443
+connect = obs.openhpc.community:{{ stunnel_remote_port }}
 cert = /etc/stunnel/stunnel.pem


### PR DESCRIPTION
Convert static stunnel.conf and openvpn-obs.conf files to templates to enable dynamic configuration via ansible variables. Also, add task to include ohpc-lenovo-common.yml.