### PR TITLE
ci: fix duplicate zero in error analysis output

### DIFF
--- a/ansible/roles/test/files/run-ci.sh
+++ b/ansible/roles/test/files/run-ci.sh
@@ -330,10 +330,10 @@ cleanup() {
 			echo "# Error Analysis"
 
 			# Count different types of errors from console output
-			COMPILE_ERRORS=$(grep -c -i "compilation.*failed\|make.*error\|gcc.*error\|error.*compiling" "${OUT}/console.out" 2>/dev/null || echo "0")
-			TIMEOUT_ERRORS=$(grep -c -i "timeout\|timed out" "${OUT}/console.out" 2>/dev/null || echo "0")
-			NETWORK_ERRORS=$(grep -c -i "network.*error\|connection.*failed\|network.*unreachable" "${OUT}/console.out" 2>/dev/null || echo "0")
-			PERMISSION_ERRORS=$(grep -c -i "permission denied\|access denied\|insufficient.*permission" "${OUT}/console.out" 2>/dev/null || echo "0")
+			COMPILE_ERRORS=$(grep -c -i "compilation.*failed\|make.*error\|gcc.*error\|error.*compiling" "${OUT}/console.out" 2>/dev/null || true)
+			TIMEOUT_ERRORS=$(grep -c -i "timeout\|timed out" "${OUT}/console.out" 2>/dev/null || true)
+			NETWORK_ERRORS=$(grep -c -i "network.*error\|connection.*failed\|network.*unreachable" "${OUT}/console.out" 2>/dev/null || true)
+			PERMISSION_ERRORS=$(grep -c -i "permission denied\|access denied\|insufficient.*permission" "${OUT}/console.out" 2>/dev/null || true)
 
 			echo "COMPILE_ERRORS=${COMPILE_ERRORS}"
 			echo "TIMEOUT_ERRORS=${TIMEOUT_ERRORS}"


### PR DESCRIPTION
grep -c already outputs 0 when no matches are found, but returns exit code 1 which triggered the '|| echo "0"' fallback, producing a duplicate 0 on a separate line. This broke sourcing the INFO file in a shell. Replace with '|| true' to suppress the exit code without adding extra output.

Generated with Claude Code (https://claude.ai/code)