### PR TITLE
ci: add inotifywait watcher for /results updates

### DIFF
--- a/ansible/roles/repos/files/update-results-watcher.service
+++ b/ansible/roles/repos/files/update-results-watcher.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Watch /results for changes and update result pages
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/ohpc/bin/update-results-watcher.sh
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/repos/files/update-results-watcher.sh
+++ b/ansible/roles/repos/files/update-results-watcher.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Watch /results for changes and run update_results.sh for the affected version.
+# Events are batched: after detecting a change, wait BATCH_DELAY seconds and
+# coalesce multiple events for the same version into a single update call.
+
+set -euo pipefail
+
+WATCH_DIR="/results"
+BATCH_DELAY=5
+QUEUE_DIR=$(mktemp -d)
+
+cleanup() {
+	rm -rf "$QUEUE_DIR"
+}
+trap cleanup EXIT
+
+while read -r path; do
+	# Strip the watch directory prefix and leading slash
+	rel="${path#"$WATCH_DIR"}"
+	rel="${rel#/}"
+
+	# Split into components: major/full/rest...
+	IFS='/' read -r major full rest <<<"$rel"
+
+	echo "$(date '+%Y-%m-%d %H:%M:%S') inotify: $path"
+
+	# Ignore changes that are not at least 3 levels deep
+	# (i.e., must have major, full, and something underneath)
+	if [ -z "$major" ] || [ -z "$full" ] || [ -z "$rest" ]; then
+		continue
+	fi
+
+	marker="$QUEUE_DIR/${major}_${full}"
+
+	# If no pending update for this version, schedule one
+	if [ ! -e "$marker" ]; then
+		touch "$marker"
+		(
+			sleep "$BATCH_DELAY"
+			rm -f "$marker"
+			echo "$(date '+%Y-%m-%d %H:%M:%S') Running update_results.sh $major $full"
+			runuser -u ohpc -- /home/ohpc/bin/update_results.sh "$major" "$full" || true
+		) &
+	fi
+done < <(inotifywait -m -r -e create,modify,delete,moved_to \
+	--exclude '\.(htaccess|htaccess\.new)|HEADER\.html|FOOTER\.html|/sed[a-zA-Z0-9]+$' \
+	--format '%w%f' "$WATCH_DIR")

--- a/ansible/roles/repos/repos-aarch64.yml
+++ b/ansible/roles/repos/repos-aarch64.yml
@@ -30,6 +30,7 @@
           - ShellCheck
           - openssl-devel
           - moreutils
+          - inotify-tools
 
     - name: Include fail2ban.yml
       ansible.builtin.include_tasks: ../common/fail2ban.yml
@@ -306,8 +307,33 @@
         - move-httpd-logs.sh
         - mk_dist.sh
         - make_repo.sh
+        - update-results-watcher.sh
       tags:
         - install-helper-scripts
+        - update-results-watcher
+
+    - name: Install update-results-watcher service
+      ansible.builtin.copy:
+        src: update-results-watcher.service
+        dest: /etc/systemd/system/update-results-watcher.service
+        owner: root
+        group: root
+        mode: "0644"
+      register: results_watcher_service
+      notify:
+        - Systemd daemon-reload
+      tags:
+        - update-results-watcher
+
+    - name: Enable update-results-watcher service
+      ansible.builtin.systemd_service:
+        name: update-results-watcher
+        state: started
+        enabled: true
+      when: results_watcher_service.changed
+      tags:
+        - skip_ansible_lint
+        - update-results-watcher
 
     - name: Copy public keys
       ansible.builtin.copy:


### PR DESCRIPTION
Add a systemd service that watches /results using inotifywait and calls update_results.sh only for the specific version subdirectory that changed, avoiding full regeneration. Events are batched with a 5-second window to coalesce bulk file uploads into a single update_results.sh call.