### PR TITLE
ci: add mvapich2 to MPI test families on x86_64

### DIFF
--- a/ansible/roles/test/files/run-ci.sh
+++ b/ansible/roles/test/files/run-ci.sh
@@ -415,6 +415,8 @@ USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --disable-opencoarrays"
 
 if [[ "${VERSION_MAJOR}" == "2" ]]; then
 	USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --with-mpi-families='mpich openmpi4'"
+elif [[ "${TEST_ARCH}" == "x86_64" ]]; then
+	USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --with-mpi-families='mpich mvapich2 openmpi5'"
 else
 	USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --with-mpi-families='mpich openmpi5'"
 fi

--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -500,6 +500,9 @@ post_install_cmds() {
 	if [ "${RMS}" == "slurm" ]; then
 		install_package slurm-sview-ohpc
 	fi
+	if [[ "${Architecture}" == "x86_64" ]]; then
+		install_package ohpc-gnu15-mvapich2-parallel-libs
+	fi
 	# shellcheck disable=SC2153
 	if [[ "${VERSION_MAJOR}" == "2" ]]; then
 		# The other release branches have switched to bats native junit results


### PR DESCRIPTION
Include mvapich2 in --with-mpi-families when running on x86_64 clusters and install ohpc-gnu15-mvapich2-parallel-libs package on x86_64 to support mvapich2 testing.