### PR TITLE
ci: add permissions to workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,8 @@ name: Validate
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
 
 jobs:
   lint_markdown:


### PR DESCRIPTION
Add top-level permissions with contents:read to satisfy CodeQL security alerts about missing workflow permissions.