### PR TITLE
ci: remove all IB modules and update openEuler mirrors

### DIFF
--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -718,7 +718,9 @@ wait_for_computes() {
 		pdsh -w "${compute_prefix}"[1-"${num_computes}"] systemctl disable --now firewalld
 		if [ "${enable_ib}" -eq 0 ]; then
 			# Disable IB
-			pdsh -w "${compute_prefix}"[1-"${num_computes}"] rmmod mlx5_ib mlx5_core mlx5_fwctl mlxfw
+			pdsh -w "${compute_prefix}"[1-"${num_computes}"] rmmod mlx5_ib mlx5_core mlx5_fwctl mlxfw rdma_cm ib_ipoib rpcrdma ib_srpt iw_cm ib_iser ib_umad ib_isert rdma_ucm ib_uverbs qedr ib_cm ib_core
+			pdsh -w "${compute_prefix}"[1-"${num_computes}"] rmmod mlx5_ib mlx5_core mlx5_fwctl mlxfw rdma_cm ib_ipoib rpcrdma ib_srpt iw_cm ib_iser ib_umad ib_isert rdma_ucm ib_uverbs qedr ib_cm ib_core
+			pdsh -w "${compute_prefix}"[1-"${num_computes}"] rmmod mlx5_ib mlx5_core mlx5_fwctl mlxfw rdma_cm ib_ipoib rpcrdma ib_srpt iw_cm ib_iser ib_umad ib_isert rdma_ucm ib_uverbs qedr ib_cm ib_core
 		fi
 	fi
 

--- a/ansible/roles/test/templates/el-kickstart
+++ b/ansible/roles/test/templates/el-kickstart
@@ -30,10 +30,11 @@
 {%- endif -%}
 {%- set base = 'openEuler-'~release~'-LTS-'~SP~'-everything/' -%}
 {%- if inventory_hostname_short.startswith('ohpc-lenovo-repo') -%}
-{%- set mirror1_base = 'http://mirrors.dotsrc.org/openeuler/openEuler-'~release~'-LTS-'~SP~'/' -%}
+{%- set mirror1 = 'http://mirror.accum.se/mirror/openeuler.org/' -%}
 {%- elif inventory_hostname_short.startswith('ohpc-huawei-repo') -%}
-{%- set mirror1_base = 'http://mirrors.nju.edu.cn/openeuler/openEuler-'~release~'-LTS-'~SP~'/' -%}
+{%- set mirror1 = 'http://mirrors.nju.edu.cn/openeuler/' -%}
 {%- endif -%}
+{%- set mirror1_base = mirror1~'/openEuler-'~release~'-LTS-'~SP~'/' -%}
 {%- endif -%}
 
 text
@@ -179,6 +180,9 @@ curl -so /dev/null http://{{ repo }}/kickstart-progress/post-started-{{ distro }
 	echo "gpgcheck=0" >> /etc/yum.repos.d/updateMirror.repo
 	sed -i "s,\(metalink\),#\1,g" -i /etc/yum.repos.d/openEuler.repo
 	sed -e "s,\(baseurl=http\)s,\1,g" -i /etc/yum.repos.d/openEuler.repo
+
+	sed -i "s@http://repo.openeuler.org/@{{ mirror1 }}@g" /etc/yum.repos.d/openEuler.repo
+
 	sed '/Banner/d;/AllowTcpForwarding/d;/AllowAgentForwarding/d;/GatewayPorts/d;/PermitTunnel/d;' -i /etc/ssh/sshd_config
 	sed 's,/usr/libexec/openssh/openssh/sftp-server,/usr/libexec/openssh/sftp-server,g;' -i /etc/ssh/sshd_config
 	{% if inventory_hostname_short.startswith('ohpc-huawei-repo') %}


### PR DESCRIPTION
Expand rmmod to remove all InfiniBand kernel modules (not just mlx5) and repeat three times to handle dependency ordering. Update openEuler kickstart to use new mirrors (accum.se for Lenovo, nju.edu.cn for Huawei) and rewrite repo.openeuler.org URLs to use the selected mirror.