### PR TITLE
ci: pre-stage EasyBuild source tarballs for CI tests

### DIFF
--- a/ansible/roles/test/files/run-ci.sh
+++ b/ansible/roles/test/files/run-ci.sh
@@ -553,6 +553,12 @@ if [ -n "${ENABLE_TODISK}" ]; then
 	echo "export enable_todisk=1" >>"${VARS}"
 fi
 
+# Pre-stage EasyBuild source tarballs to avoid mirror failures
+if [ -d /var/www/html/easybuild ]; then
+	echo "Uploading pre-downloaded EasyBuild sources to ${SMS}"
+	rsync -a /var/www/html/easybuild "${SMS}":/tmp/
+fi
+
 scp "${VARS}" "${SMS}":/root/vars
 scp /root/.bash_history "${SMS}":
 

--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -527,6 +527,21 @@ post_install_cmds() {
 		echo "Syncing time on compute nodes"
 		pdsh -w "${compute_prefix}"[1-"${num_computes}"] "chronyc -m 'burst 3/3' 'makestep 0.1 3'"
 	fi
+
+	# Pre-stage EasyBuild source tarballs to avoid download failures
+	# when upstream mirrors are unstable
+	if [ -d /tmp/easybuild ]; then
+		local EB_VERSION
+		EB_VERSION=$(rpm -q --queryformat '%{version}' EasyBuild-ohpc 2>/dev/null)
+		if [ -n "${EB_VERSION}" ]; then
+			local EB_SOURCEPATH
+			EB_SOURCEPATH="/opt/ohpc/pub/libs/easybuild/${EB_VERSION}/easybuild/easyconfigs"
+			echo "Pre-staging EasyBuild source tarballs to ${EB_SOURCEPATH}"
+			cp -a /tmp/easybuild/* "${EB_SOURCEPATH}/"
+		else
+			echo "WARNING: Could not determine EasyBuild version, skipping source pre-staging"
+		fi
+	fi
 }
 
 gen_localized_inputs() {


### PR DESCRIPTION
Upload pre-downloaded source tarballs from /var/www/html/easybuild on the CI runner to ${SMS}:/tmp/easybuild via rsync. After the recipe finishes, copy them into the EasyBuild easyconfigs directory so that EasyBuild finds them locally instead of downloading from potentially unstable mirrors.

Generated with Claude Code (https://claude.ai/code)