### PR TITLE
obs: fix skip_on_distro adding distro as individual chars

### DIFF
--- a/obs/obs_config.py
+++ b/obs/obs_config.py
@@ -178,7 +178,7 @@ class ohpc_obs_tool(object):
                         )
                         for pkg in pkgs_to_skip:
                             try:
-                                self.skip_on_distro[pkg].extend(distro_to_skip)
+                                self.skip_on_distro[pkg].append(distro_to_skip)
                             except KeyError:
                                 self.skip_on_distro[pkg] = [distro_to_skip]
 


### PR DESCRIPTION
Replace list.extend() with list.append() when adding a distro to skip_on_distro. extend() iterates over the string, adding each character as a separate list entry instead of the whole distro name as a single entry.