### PR TITLE
ci: generalize version checks for multi-version support

### DIFF
--- a/ansible/roles/repos/repos-aarch64.yml
+++ b/ansible/roles/repos/repos-aarch64.yml
@@ -177,7 +177,7 @@
         - results.conf
         - welcome.conf
         - ssl.conf
-      register: httpd_conf
+      register: repos_httpd_conf
       tags:
         - httpd-conf
 
@@ -236,7 +236,7 @@
       with_items:
         - certbot-renewal.service
         - certbot-renewal.timer
-      register: certbot_timer
+      register: repos_certbot_timer
       notify:
         - Systemd daemon-reload
 
@@ -245,7 +245,7 @@
         name: certbot-renewal.timer
         state: started
         enabled: true
-      when: certbot_timer.changed
+      when: repos_certbot_timer.changed
       tags:
         - skip_ansible_lint
 
@@ -282,14 +282,14 @@
         owner: root
         group: root
         mode: "0644"
-      register: rsyncd_conf
+      register: repos_rsyncd_conf
 
     - name: Enable rsyncd
       ansible.builtin.systemd_service:
         name: rsyncd
         state: started
         enabled: true
-      when: rsyncd_conf.changed
+      when: repos_rsyncd_conf.changed
       tags:
         - skip_ansible_lint
 
@@ -319,7 +319,7 @@
         owner: root
         group: root
         mode: "0644"
-      register: results_watcher_service
+      register: repos_results_watcher_service
       notify:
         - Systemd daemon-reload
       tags:
@@ -330,7 +330,7 @@
         name: update-results-watcher
         state: started
         enabled: true
-      when: results_watcher_service.changed
+      when: repos_results_watcher_service.changed
       tags:
         - skip_ansible_lint
         - update-results-watcher
@@ -369,7 +369,7 @@
         version: 4d2ab27d6eff2f28f8be27540ed9182fb8ba2934
       become: true
       become_user: ohpc
-      register: ohpc_log_analyzer_downloaded
+      register: repos_ohpc_log_analyzer_downloaded
 
     - name: Build ohpc-log-analyzer
       ansible.builtin.command: "cargo build --release"
@@ -378,7 +378,7 @@
       become: true
       become_user: ohpc
       register: ohpc_log_analyzer_built
-      when: ohpc_log_analyzer_downloaded.changed
+      when: repos_ohpc_log_analyzer_downloaded.changed
       tags:
         - skip_ansible_lint
 

--- a/ansible/roles/test/files/install.sh
+++ b/ansible/roles/test/files/install.sh
@@ -171,10 +171,10 @@ inputTemplate=/opt/ohpc/pub/doc/recipes/${os_major}/input.local
 inputFile=/root/ci_ohpc_inputs
 status=0
 
-# For OpenHPC 4, "warewulf" is Warewulf v4 (not v3 as in OHPC 2/3).
+# For OpenHPC 3+, "warewulf" is Warewulf v4 (not v3 as in OHPC 2).
 # Normalize Provisioner to "warewulf4" so that all existing conditionals
 # comparing against "warewulf4" are triggered correctly.
-if [[ "${VERSION_MAJOR}" == "4" ]] && [[ "${Provisioner}" == "warewulf" ]]; then
+if [[ "${VERSION_MAJOR}" != "2" ]] && [[ "${Provisioner}" == "warewulf" ]]; then
 	Provisioner="warewulf4"
 fi
 

--- a/ansible/roles/test/files/run-ci.sh
+++ b/ansible/roles/test/files/run-ci.sh
@@ -415,7 +415,7 @@ USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --disable-opencoarrays"
 
 if [[ "${VERSION_MAJOR}" == "2" ]]; then
 	USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --with-mpi-families='mpich openmpi4'"
-elif [[ "${TEST_ARCH}" == "x86_64" ]]; then
+elif [[ "${TEST_ARCH}" == "x86_64" ]] && [[ "${VERSION_MAJOR}" == "4" ]]; then
 	USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --with-mpi-families='mpich mvapich2 openmpi5'"
 else
 	USER_TEST_OPTIONS="${USER_TEST_OPTIONS} --with-mpi-families='mpich openmpi5'"

--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -222,6 +222,7 @@ export SINGULARITY_TMPDIR=/var/tmp
 export FI_PROVIDER=sockets
 EOF
 
+	# shellcheck disable=SC2153
 	if [[ "${VERSION_MAJOR}" -lt 4 ]]; then
 		echo "export PATH=/opt/ohpc/pub/utils/autotools/bin:\$PATH" >>/tmp/user_integration_tests
 	fi

--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -222,6 +222,10 @@ export SINGULARITY_TMPDIR=/var/tmp
 export FI_PROVIDER=sockets
 EOF
 
+	if [[ "${VERSION_MAJOR}" -lt 4 ]]; then
+		echo "export PATH=/opt/ohpc/pub/utils/autotools/bin:\$PATH" >>/tmp/user_integration_tests
+	fi
+
 	if [[ ${CI_CLUSTER} == "linaro" ]]; then
 		{
 			echo "export FI_PROVIDER=\"tcp;ofi_rxm\""

--- a/ansible/roles/test/ohpc-huawei-sms.yml
+++ b/ansible/roles/test/ohpc-huawei-sms.yml
@@ -17,7 +17,7 @@
         path: /etc/chrony.conf
         state: present
         line: 'server 175.200.16.14'
-      register: chrony_changed
+      register: test_chrony_changed
 
     - name: Allow time jumps
       ansible.builtin.lineinfile:


### PR DESCRIPTION
Broaden the warewulf4 provisioner normalization to apply to all versions except OHPC 2. Restrict mvapich2 MPI family selection to version 4 on x86_64. Add autotools to PATH for versions earlier than 4 in user integration tests.