### PR TITLE
ci: configure dnf parallel downloads and reduce log noise

### DIFF
--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -407,6 +407,14 @@ install_openHPC_cluster() {
 	echo "DISTRIBUTION = $DISTRIBUTION"
 	echo "CI_CLUSTER = $CI_CLUSTER"
 
+	if [ "${PKG_MANAGER}" == "dnf" ]; then
+		echo "CI Customization: Speed up dnf and reduce log noise"
+		echo "max_parallel_downloads=10" >>/etc/dnf/dnf.conf
+		echo "debuglevel=1" >>/etc/dnf/dnf.conf
+		# shellcheck disable=SC2016
+		sed 's|#<<< ohpc_proxy:compute >>>#|echo "max_parallel_downloads=10" >> $CHROOT/etc/dnf/dnf.conf\necho "debuglevel=1" >> $CHROOT/etc/dnf/dnf.conf|' -i "${recipeFile}"
+	fi
+
 	if [ "${EnableArmCompiler}" == "true" ]; then
 		# enable local ARM1 repository
 		sed -e "s,install arm1-compilers-devel-ohpc,install --enablerepo=ARM1 arm1-compilers-devel-ohpc,g" -i "${recipeFile}"


### PR DESCRIPTION
Set max_parallel_downloads=10 and debuglevel=1 in dnf.conf on the host and patch the recipe to apply the same settings to compute node images via the ohpc_proxy:compute marker.