### PR TITLE
ci: fix Factory repo addition for client YAML config

### DIFF
--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -367,7 +367,13 @@ install_openHPC_cluster() {
 				else
 					# Add Factory repo for host
 					# shellcheck disable=SC2153
-					sed -e "/ohpc-release/a dnf config-manager --add-repo http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/" -i "${recipeFile}"
+					sed -e "/^ *-.*ohpc-release/!{/ohpc-release/a dnf config-manager --add-repo http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/
+}" -i "${recipeFile}"
+					# Add Factory repo for client
+					sed -e "/gpg:.*RPM-GPG-KEY-OpenHPC/a\\
+  - alias: 'OpenHPC-Factory'\\
+    url: 'http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/'\\
+    gpg: 'http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/repodata/repomd.xml.key'" -i "${recipeFile}"
 				fi
 				# Add Factory repo for client
 				sed -e "s,\(cmd: dnf config-manager --set-enabled crb\),\1 ; dnf config-manager --add-repo http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/; echo user_agent=curl >> /etc/dnf/dnf.conf,g" -i "${recipeFile}"


### PR DESCRIPTION
The sed pattern /ohpc-release/a matched in both the host shell section and the client YAML section, inserting a raw shell command into the YAML and producing an invalid config. Restrict the host sed to skip YAML list items and add a proper YAML repo entry for the client with the correct alias, url, and gpg key.