### PR TITLE
ci: fix sed patterns for Factory repo in openchami

### DIFF
--- a/ansible/roles/test/files/support_functions.sh
+++ b/ansible/roles/test/files/support_functions.sh
@@ -367,10 +367,9 @@ install_openHPC_cluster() {
 				else
 					# Add Factory repo for host
 					# shellcheck disable=SC2153
-					sed -e "/^ *-.*ohpc-release/!{/ohpc-release/a dnf config-manager --add-repo http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/
-}" -i "${recipeFile}"
+					sed -e "/Install OpenHPC ohpc-release/a dnf config-manager --add-repo http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/" -i "${recipeFile}"
 					# Add Factory repo for client
-					sed -e "/gpg:.*RPM-GPG-KEY-OpenHPC/a\\
+					sed -e "/gpg:.*RPM-GPG-KEY-EPEL/a\\
   - alias: 'OpenHPC-Factory'\\
     url: 'http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/'\\
     gpg: 'http://obs.openhpc.community:82/OpenHPC${VERSION_MAJOR}:/${Version}:/Factory/${os_repo}/repodata/repomd.xml.key'" -i "${recipeFile}"


### PR DESCRIPTION
The negated-address sed pattern for the host Factory repo was unreliable and also matched ohpc-release in the client YAML packages section, inserting a raw shell command into the YAML. Use the 'Install OpenHPC ohpc-release' echo line as the anchor for the host instead.

For the client repos, use the EPEL GPG key as the anchor to insert the Factory repo entry in compute-base.yaml which is the YAML that contains the ohpc-release RPM in its packages.