### PR TITLE
ci: disable metalink in Leap installer and installed system

### DIFF
--- a/ansible/roles/test/templates/grub.cfg
+++ b/ansible/roles/test/templates/grub.cfg
@@ -19,7 +19,7 @@ set timeout=1
 
 menuentry 'Install' {
 {%- if distro.startswith('leap15') %}
-  linux linux ro autoyast=http://{{ repo }}/{{ distro }}-autoyast install=http://{{ repo }}/openSUSE-Leap-{{ distro[4:] }}-DVD-{{ arch }}-Current ifcfg={{ interface }}=dhcp textmode=1 display=1 proxy={{ proxy }} vnc=1 VNCPassword=12345678
+  linux linux ro autoyast=http://{{ repo }}/{{ distro }}-autoyast install=http://{{ repo }}/openSUSE-Leap-{{ distro[4:] }}-DVD-{{ arch }}-Current ifcfg={{ interface }}=dhcp textmode=1 display=1 proxy={{ proxy }} vnc=1 VNCPassword=12345678 zyppargs="--option download.use_metalink=false"
   initrd initrd
 {% else %}
   linux vmlinuz ro ip={{ interface }}:dhcp inst.ks=http://{{ repo }}/{{ distro }}-kickstart

--- a/ansible/roles/test/templates/leap15.5-autoyast
+++ b/ansible/roles/test/templates/leap15.5-autoyast
@@ -172,6 +172,10 @@ curl -so /dev/null http://{{ repo }}/autoyast-progress/pre-install-leap15.5 || t
 					<![CDATA[
 curl -so /dev/null http://{{ repo }}/autoyast-progress/post-started-leap15.5 || true
 systemctl stop sshd
+# Metalink causes zypper to use partial/range downloads which
+# breaks caching in the squid proxy.
+mkdir -p /etc/zypp
+echo "download.use_metalink = false" >> /etc/zypp/zypp.conf
 curl -so /dev/null http://{{ repo }}/autoyast-progress/zypper-update-leap15.5 || true
 zypper -n update
 curl -so /dev/null http://{{ repo }}/autoyast-progress/zypper-update-done-leap15.5 || true
@@ -200,6 +204,7 @@ curl -so /dev/null http://{{ repo }}/autoyast-progress/post-complete-leap15.5 ||
 			<script>
 				<source>
 					<![CDATA[
+curl -so /dev/null http://{{ repo }}/autoyast-progress/init-scripts-leap15.5 || true
 systemctl enable sshd
 			]]>
 				</source>


### PR DESCRIPTION
Pass zyppargs on the kernel command line to disable metalink during AutoYaST installation. Also disable metalink in the installed system's zypp.conf before running zypper update, so that all zypper downloads go through the squid proxy without partial/range requests. Add init-scripts progress marker.