### PR TITLE
obs: fix copr_bridge API parameter and make chroot optional

### DIFF
--- a/ansible/roles/obs/files/copr_bridge.py
+++ b/ansible/roles/obs/files/copr_bridge.py
@@ -217,11 +217,14 @@ class CoprBridge:
         logging.info("Submitting %s to COPR %s", srpm_path.name, self.copr_project)
 
         try:
+            buildopts = {}
+            if self.chroot:
+                buildopts["chroots"] = [self.chroot]
             build = self.client.build_proxy.create_from_file(
                 ownername=self.ownername,
                 projectname=self.projectname,
-                file_path=str(srpm_path),
-                buildopts={"chroots": [self.chroot]},
+                path=str(srpm_path),
+                buildopts=buildopts if buildopts else None,
             )
             logging.info(
                 "Build submitted: id=%d, url=https://copr.fedorainfracloud.org"
@@ -538,8 +541,7 @@ def main():
     )
     parser.add_argument(
         "--chroot",
-        required=True,
-        help="COPR chroot (e.g. rhel+epel-10-ppc64le)",
+        help="COPR chroot to build for (default: all project chroots)",
         type=str,
     )
     parser.add_argument(


### PR DESCRIPTION
Fix create_from_file() call to use 'path' instead of 'file_path' to match the copr.v3 API. Make --chroot optional so COPR builds for all chroots configured in the project when not specified.

Generated with Claude Code (https://claude.ai/code)