### PR TITLE
obs: fix reset-failed to delete state entry and update test

### DIFF
--- a/ansible/roles/obs/files/copr_bridge.py
+++ b/ansible/roles/obs/files/copr_bridge.py
@@ -210,7 +210,7 @@ class CoprBridge:
         # Dry-run entries do not count as processed
         if entry.get("reason") == "dry-run":
             return False
-        return entry["status"] in ("succeeded", "skipped", "acknowledged")
+        return entry["status"] in ("succeeded", "skipped")
 
     def submit_build(self, srpm_path):
         """Upload SRPM to COPR and return the build object."""
@@ -486,7 +486,7 @@ class CoprBridge:
             watcher.close()
 
     def reset_failed(self, srpm_name):
-        """Mark a failed SRPM as acknowledged so processing can continue."""
+        """Remove a failed SRPM from state so it will be retried."""
         if srpm_name not in self.state["builds"]:
             ERROR("SRPM '%s' not found in state file" % srpm_name)
 
@@ -497,18 +497,17 @@ class CoprBridge:
                 % (srpm_name, entry["status"])
             )
 
-        entry["original_status"] = entry["status"]
-        entry["status"] = "acknowledged"
-        entry["acknowledged_at"] = now_iso()
+        old_status = entry["status"]
+        del self.state["builds"][srpm_name]
 
         if self.state["blocked_on"] == srpm_name:
             self.state["blocked_on"] = None
 
         self.save_state()
         logging.info(
-            "Reset '%s' from '%s' to 'acknowledged'. Processing can continue.",
+            "Removed '%s' (was '%s') from state. It will be retried on next run.",
             srpm_name,
-            entry["original_status"],
+            old_status,
         )
 
     def setup_signal_handlers(self):

--- a/ansible/roles/obs/files/test_copr_bridge.bats
+++ b/ansible/roles/obs/files/test_copr_bridge.bats
@@ -284,19 +284,19 @@ for name, b in s['builds'].items():
 		--state-file "${STATE_FILE}" \
 		--reset-failed "broken-ohpc-1.0-1.src.rpm"
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"acknowledged"* ]]
+	[[ "$output" == *"Removed"* ]]
 
 	# Verify blocked_on is cleared
 	blocked=$(python3 -c "import json; print(json.load(open('${STATE_FILE}'))['blocked_on'])")
 	[ "$blocked" = "None" ]
 
-	# Verify the entry status is now acknowledged
-	status_val=$(python3 -c "
+	# Verify the entry is removed from builds
+	absent=$(python3 -c "
 import json
 s = json.load(open('${STATE_FILE}'))
-print(s['builds']['broken-ohpc-1.0-1.src.rpm']['status'])
+print('broken-ohpc-1.0-1.src.rpm' not in s['builds'])
 ")
-	[ "$status_val" = "acknowledged" ]
+	[ "$absent" = "True" ]
 
 	# Now a scan should work without error
 	run python3 "${SCRIPT}" \


### PR DESCRIPTION
reset_failed() now deletes the entry from state instead of marking it "acknowledged", so remove the dead "acknowledged" status from already_processed() and update the BATS test to verify the entry is removed from state rather than marked as acknowledged.

Generated with Claude Code (https://claude.ai/code)